### PR TITLE
Make script compatible with Tenshitachi no Gogo 3 Bangaihen FDI images

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -1,25 +1,33 @@
 import struct
 
-def read_index_entries(file_path, offset, entry_size, num_entries):
-    with open(file_path, 'rb') as f:
-        f.seek(offset)
-        index_entries = []
-        for _ in range(num_entries):
-            entry = f.read(entry_size)
-            if len(entry) < entry_size:
-                break  # End of file or malformed entry
-            # Unpack entry as (DD, SS, ls, LL)
-            disk_number = entry[0]
-            start_sector = (entry[1] << 8) | entry[2]
-            length = entry[3]  # Correctly using the 4th byte for length
-            index_entries.append((disk_number, start_sector, length))
-        return index_entries
+def read_index_entries(file_data, offset):
+    entry_size = 4
+    index_entries = []
+    offset += 0x1000 # Skip FDI header
+    while (offset + 4 <= len(file_data)) and (file_data[offset] != 0):
+        # Unpack entry as (DD, SS, ls, LL) -> disk DD, start sector sSS, length in sectors LLl
+        disk_number = file_data[offset]
+        start_sector = file_data[offset + 1] | ((file_data[offset + 2] & 0x0F) << 8)
+        length = (file_data[offset + 3] << 4) | ((file_data[offset + 2] & 0xF0) >> 4)
+        index_entries.append((disk_number, start_sector, length))
 
-def extract_data_from_sectors(disk_path, start_sector, num_sectors, sector_size=512):
-    with open(disk_path, 'rb') as f:
-        f.seek(start_sector * sector_size)
-        data = f.read(num_sectors * sector_size)
-        return data
+        offset += 4
+    return index_entries
+
+def extract_data_from_sectors(disk_data, start_sector, num_sectors, sector_size=0x400):
+    offset = start_sector * sector_size
+    offset += 0x1000 # Skip FDI header
+    end_offset = offset + num_sectors * sector_size
+    data = disk_data[offset:end_offset]
+    return data
+
+def extract_entries(disk1_data, disk2_data, index_entries, suffix):
+    for i, (disk_number, start_sector, length) in enumerate(index_entries):
+        disk_data = disk2_data if disk_number == 2 else disk1_data
+        data = extract_data_from_sectors(disk_data, start_sector, length)
+        output_file_path = f'{suffix}_{i}.{suffix}'
+        save_data(data, output_file_path)
+        print(f'Extracted file {i}: {output_file_path}')
 
 def save_data(data, output_path):
     with open(output_path, 'wb') as f:
@@ -28,18 +36,21 @@ def save_data(data, output_path):
 def main():
     disk1_file_path = 'ten_a.fdi'  # Path to the first disk image
     disk2_file_path = 'ten_b.fdi'  # Path to the second disk image
-    index_offset = 0x1412
-    entry_size = 4
+    index_offsets = [0x2412, 0x2612, 0x2812, 0x2A12] # All on the first disk
     num_entries = 10  # Number of entries in the index (adjust based on your file)
 
-    index_entries = read_index_entries(disk1_file_path, index_offset, entry_size, num_entries)
+    with open(disk1_file_path, 'rb') as f: disk1_data = f.read()
+    with open(disk2_file_path, 'rb') as f: disk2_data = f.read()
 
-    for i, (disk_number, start_sector, length) in enumerate(index_entries):
-        disk_path = disk2_file_path if disk_number == 2 else disk1_file_path
-        data = extract_data_from_sectors(disk_path, start_sector, length)
-        output_file_path = f'extracted_file_{i}.bin'
-        save_data(data, output_file_path)
-        print(f'Extracted file {i}: {output_file_path}')
+    graphic_entries = read_index_entries(disk1_data, index_offsets[0])
+    animation_entries = read_index_entries(disk1_data, index_offsets[1])
+    script_entries = read_index_entries(disk1_data, index_offsets[2])
+    music_entries = read_index_entries(disk1_data, index_offsets[3])
+
+    extract_entries(disk1_data, disk2_data, graphic_entries, 'img')
+    extract_entries(disk1_data, disk2_data, animation_entries, 'ani')
+    extract_entries(disk1_data, disk2_data, script_entries, 'scd')
+    extract_entries(disk1_data, disk2_data, music_entries, 'mus')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Summary of changes: It skips over the FDI header so offsets are correct, reads both files into memory once at the start for maybe simpler operation, autodetects the end of each resource array when disk "00" is encountered, extracts all four resource types, and uses appropriate type names for them.